### PR TITLE
feat: add animation when toggle dark/light mode

### DIFF
--- a/src/layouts/_common/setting-button.tsx
+++ b/src/layouts/_common/setting-button.tsx
@@ -8,6 +8,7 @@ import { Button, Card, Drawer, Switch, Tooltip } from 'antd';
 import Color from 'color';
 import { m } from 'framer-motion';
 import { CSSProperties, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { MdCircle } from 'react-icons/md';
 import screenfull from 'screenfull';
 
@@ -35,10 +36,21 @@ export default function SettingButton() {
   const { setSettings } = useSettingActions();
 
   const setThemeMode = (themeMode: ThemeMode) => {
-    setSettings({
-      ...settings,
-      themeMode,
-    });
+    if (!document.startViewTransition) {
+      setSettings({
+        ...settings,
+        themeMode,
+      });
+    } else {
+      document.startViewTransition(() => {
+        flushSync(() => {
+          setSettings({
+            ...settings,
+            themeMode,
+          });
+        });
+      });
+    }
   };
 
   const setThemeColorPresets = (themeColorPresets: ThemeColorPresets) => {

--- a/src/theme/base.css
+++ b/src/theme/base.css
@@ -2,6 +2,23 @@
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
 */
+@keyframes clip {
+  from {
+    clip-path: ellipse(120px 120px at 100% 0);
+  }
+
+  to{
+    clip-path: ellipse(100% 100% at 100% 0);
+  }
+}
+
+::view-transition-old(root){
+  animation: none;
+}
+
+::view-transition-new(root) {
+  animation: clip .5s ease-in;
+}
 
 *,
 ::before,

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -8,6 +8,10 @@ declare global {
   interface Window {
     hljs: any;
   }
+
+  interface Document {
+    startViewTransition: (callback: () => void) => void;
+  }
 }
 
 hljs.configure({


### PR DESCRIPTION
Add simple animation when toggle dark/light mode, it looks like below:

Implemented by using [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) 

Note: current animation is very simple, just [clip-path](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path) from 0 to 100%, and hard code way is not better.

![add-animation-on-theme-change](https://github.com/d3george/slash-admin/assets/37979965/a5569498-e3f6-40f4-abbc-1014818f3c75)

