### PR TITLE
fix: don't open a blank tab in project when click a external link menu #16

### DIFF
--- a/src/_mock/assets.js
+++ b/src/_mock/assets.js
@@ -434,6 +434,7 @@ const OTHERS_PERMISSION = [
         name: 'External Link',
         type: PermissionType.MENU,
         route: 'external_link',
+        hideTab: true,
         component: '/sys/others/iframe/external-link.tsx',
         frameSrc: 'https://ant.design/',
       },

--- a/src/layouts/dashboard/nav-horizontal.tsx
+++ b/src/layouts/dashboard/nav-horizontal.tsx
@@ -3,7 +3,7 @@ import { ItemType } from 'antd/es/menu/hooks/useItems';
 import { useState, useEffect, CSSProperties } from 'react';
 import { useNavigate, useMatches, useLocation } from 'react-router-dom';
 
-import { useRouteToMenuFn, usePermissionRoutes } from '@/router/hooks';
+import { useRouteToMenuFn, usePermissionRoutes, useFlattenedRoutes } from '@/router/hooks';
 import { menuFilter } from '@/router/utils';
 import { useThemeToken } from '@/theme/hooks';
 
@@ -18,6 +18,8 @@ export default function NavHorizontal() {
 
   const routeToMenuFn = useRouteToMenuFn();
   const permissionRoutes = usePermissionRoutes();
+  // 获取拍平后的路由菜单
+  const flattenedRoutes = useFlattenedRoutes();
 
   /**
    * state
@@ -48,6 +50,15 @@ export default function NavHorizontal() {
     }
   };
   const onClick: MenuProps['onClick'] = ({ key }) => {
+    // 从扁平化的路由信息里面匹配当前点击的那个
+    const nextLink = flattenedRoutes?.find((el) => el.key === key);
+
+    // 处理菜单项中，外链的特殊情况
+    // 点击外链时，不跳转路由，不在当前项目添加tab，不选中当前路由，新开一个 tab 打开外链
+    if (nextLink?.hideTab && nextLink?.frameSrc) {
+      window.open(nextLink?.frameSrc, '_blank');
+      return;
+    }
     navigate(key);
   };
 

--- a/src/layouts/dashboard/nav.tsx
+++ b/src/layouts/dashboard/nav.tsx
@@ -7,7 +7,7 @@ import { useLocation, useMatches, useNavigate } from 'react-router-dom';
 
 import Logo from '@/components/logo';
 import Scrollbar from '@/components/scrollbar';
-import { useRouteToMenuFn, usePermissionRoutes } from '@/router/hooks';
+import { useRouteToMenuFn, usePermissionRoutes, useFlattenedRoutes } from '@/router/hooks';
 import { menuFilter } from '@/router/utils';
 import { useSettingActions, useSettings } from '@/store/settingStore';
 import { useThemeToken } from '@/theme/hooks';
@@ -36,6 +36,8 @@ export default function Nav(props: Props) {
 
   const routeToMenuFn = useRouteToMenuFn();
   const permissionRoutes = usePermissionRoutes();
+  // 获取拍平后的路由菜单
+  const flattenedRoutes = useFlattenedRoutes();
 
   /**
    * state
@@ -85,6 +87,16 @@ export default function Nav(props: Props) {
     }
   };
   const onClick: MenuProps['onClick'] = ({ key }) => {
+    // 从扁平化的路由信息里面匹配当前点击的那个
+    const nextLink = flattenedRoutes?.find((el) => el.key === key);
+
+    // 处理菜单项中，外链的特殊情况
+    // 点击外链时，不跳转路由，不在当前项目添加tab，不选中当前路由，新开一个 tab 打开外链
+    if (nextLink?.hideTab && nextLink?.frameSrc) {
+      window.open(nextLink?.frameSrc, '_blank');
+      return;
+    }
+
     navigate(key);
     props?.closeSideBarDrawer?.();
   };

--- a/src/router/hooks/use-permission-routes.tsx
+++ b/src/router/hooks/use-permission-routes.tsx
@@ -53,6 +53,7 @@ function transformPermissionToMenuRoutes(
       icon,
       order,
       hide,
+      hideTab,
       status,
       frameSrc,
       newFeature,
@@ -67,6 +68,7 @@ function transformPermissionToMenuRoutes(
         label,
         key: getCompleteRoute(permission, flattenedPermissions),
         hideMenu: !!hide,
+        hideTab,
         disabled: status === BasicStatus.DISABLE,
       },
     };

--- a/types/entity.ts
+++ b/types/entity.ts
@@ -37,6 +37,7 @@ export interface Permission {
   icon?: string;
   component?: string;
   hide?: boolean;
+  hideTab?: boolean;
   frameSrc?: string;
   newFeature?: boolean;
   children?: Permission[];


### PR DESCRIPTION
修复 #16 
## 改动点

1. `types/entity.ts` 中 `Permission` 接口新增 `hideTab` 字段
2. `src/_mock/assets.js` 中配置返回的外链菜单配置的 `hideTab` 字段为 `true`
3. `src/router/hooks/use-permission-routes.tsx` 中，返回 `hideTab` 字段
4. `src/layouts/dashboard/nav.tsx` 中处理菜单的onClick时，判断当前点击的菜单是否为外链以及 `hideTab` 字段是否为 `true`；是外链并且`hideTab` 字段为 `true`，使用 `window.open` 打开外链同时项目内不进行路由跳转

## Before

https://github.com/d3george/slash-admin/assets/65325004/71d47820-7772-460b-8f47-8fd0da8f632a

点击外链菜单时会：
- 新增tab
- 打开新标签页
- 高亮当前点击菜单
- 路由跳转

## After

https://github.com/d3george/slash-admin/assets/65325004/a53f184a-e7b8-4170-a364-31087cff7b12

点击外链菜单时只会打开新标签页

## 如何验证：

1.  clone `fix/hide-in-multi-tab` 分支代码

```shell
git clone -b fix/hide-in-multi-tab https://github.com/aifuxi/slash-admin.git
```

2. 本地启动

```shell
# 安装依赖
pnpm install
# 启动开发环境
pnpm dev
```

3. 访问 `http://localhost:3001` 进行验证，**如果已登录，务必先退出登录后，再重新登录，防止接口有缓存**
