### PR TITLE
enhance permission

### DIFF
--- a/src/pages/management/system/permission/index.tsx
+++ b/src/pages/management/system/permission/index.tsx
@@ -106,6 +106,7 @@ export default function PermissionPage() {
       ...prev,
       show: true,
       ...defaultPermissionValue,
+      title: 'New',
     }));
   };
 

--- a/src/pages/management/system/permission/permission-modal.tsx
+++ b/src/pages/management/system/permission/permission-modal.tsx
@@ -120,7 +120,13 @@ export default function PermissionModal({
                   name="component"
                   required={formValue.type === PermissionType.MENU}
                 >
-                  <AutoComplete options={compOptions} placeholder="Please input component path" />
+                  <AutoComplete
+                    options={compOptions}
+                    placeholder="Please input component path"
+                    filterOption={(input, option) =>
+                      ((option?.label || '') as string).toLowerCase().includes(input.toLowerCase())
+                    }
+                  />
                 </Form.Item>
               );
             }

--- a/src/pages/management/system/permission/permission-modal.tsx
+++ b/src/pages/management/system/permission/permission-modal.tsx
@@ -118,11 +118,10 @@ export default function PermissionModal({
                 <Form.Item<Permission>
                   label="Component"
                   name="component"
-                  required={formValue.type === PermissionType.MENU}
+                  required={getFieldValue('type') === PermissionType.MENU}
                 >
                   <AutoComplete
                     options={compOptions}
-                    placeholder="Please input component path"
                     filterOption={(input, option) =>
                       ((option?.label || '') as string).toLowerCase().includes(input.toLowerCase())
                     }

--- a/src/router/hooks/use-permission-routes.tsx
+++ b/src/router/hooks/use-permission-routes.tsx
@@ -13,11 +13,19 @@ import { BasicStatus, PermissionType } from '#/enum';
 import { AppRouteObject } from '#/router';
 
 // 使用 import.meta.glob 获取所有路由组件
+const entryPath = '/src/pages';
 const pages = import.meta.glob('/src/pages/**/*.tsx');
+export const pagesSelect = Object.entries(pages).map(([path]) => {
+  const pagePath = path.replace(entryPath, '');
+  return {
+    label: pagePath,
+    value: pagePath,
+  };
+});
 
 // 构建绝对路径的函数
 function resolveComponent(path: string) {
-  return pages[`/src/pages${path}`];
+  return pages[`${entryPath}${path}`];
 }
 
 /**


### PR DESCRIPTION
想了下只是做提示的话，列出pages下的所有好像问题也不大。要不作者在看看给个意见？
改动如下：
1. 弹窗标题修改
2. 权限表单目录下隐藏component选项
3. component支持提示，可选可输入，且可根据parent选项过滤
4. component required 逻辑修复
![image](https://github.com/d3george/slash-admin/assets/13268002/71327f17-976d-4835-92e8-abde09eec44a)
![image](https://github.com/d3george/slash-admin/assets/13268002/3d468026-e140-458e-8e75-13cdd476393e)
