### PR TITLE
fix: quill align format not working with img

### DIFF
--- a/src/components/editor/styles.ts
+++ b/src/components/editor/styles.ts
@@ -33,6 +33,9 @@ const StyledEditor = styled.div<{ $token: GlobalToken; $thememode: ThemeMode }>`
   h5 {
     ${(props) => getHeadingStyle(5, props.$token)};
   }
+  img {
+    display: inline;
+  }
   overflow: hidden;
   position: relative;
   border-radius: 8px;


### PR DESCRIPTION
base.css的img display:block导致quill中图片居中失效
修改editor的style重置img为display:inline