### PR TITLE
chore: setup All Contributors and update README

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,92 @@
+{
+  "projectName": "slash-admin",
+  "projectOwner": "d3george",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 72,
+  "commit": false,
+  "commitConvention": "eslint",
+  "contributors": [
+    {
+      "login": "d3george",
+      "name": "kevin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/143698843?v=4",
+      "profile": "https://blog.slashspaces.com/",
+      "contributions": ["design", "tool", "code", "bug", "doc"]
+    },
+    {
+      "login": "ydiego",
+      "name": "YDiego",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13268002?v=4",
+      "profile": "https://github.com/ydiego",
+      "contributions": ["code", "bug"]
+    },
+    {
+      "login": "aifuxi",
+      "name": "付小晨",
+      "avatar_url": "https://avatars.githubusercontent.com/u/65325004?v=4",
+      "profile": "https://fuxiaochen.com/",
+      "contributions": ["code", "bug"]
+    },
+    {
+      "login": "xinmans",
+      "name": "xinmans",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2713008?v=4",
+      "profile": "https://github.com/xinmans",
+      "contributions": ["code", "tool"]
+    },
+    {
+      "login": "stitchLau",
+      "name": "stitch",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52861440?v=4",
+      "profile": "https://github.com/stitchLau",
+      "contributions": ["code", "bug"]
+    },
+    {
+      "login": "ntscshen",
+      "name": "ntscshen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21041458?v=4",
+      "profile": "https://github.com/ntscshen",
+      "contributions": ["tool"]
+    },
+    {
+      "login": "298977887",
+      "name": "298977887",
+      "avatar_url": "https://avatars.githubusercontent.com/u/127030474?v=4",
+      "profile": "https://github.com/298977887",
+      "contributions": ["code"]
+    },
+    {
+      "login": "eternallycyf",
+      "name": "eternallycyf",
+      "avatar_url": "https://avatars.githubusercontent.com/u/63464198?v=4",
+      "profile": "https://www.yuque.com/eternallycyf",
+      "contributions": ["tool"]
+    },
+    {
+      "login": "hugepizza",
+      "name": "lei",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23519941?v=4",
+      "profile": "https://github.com/hugepizza",
+      "contributions": ["bug"]
+    },
+    {
+      "login": "fliu2476",
+      "name": "fliu2476",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19582252?v=4",
+      "profile": "https://github.com/fliu2476",
+      "contributions": ["bug"]
+    },
+    {
+      "login": "chenyuxi2002",
+      "name": "tzcat8",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59554586?v=4",
+      "profile": "https://github.com/chenyuxi2002",
+      "contributions": ["doc"]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": true
+}
+

--- a/README.md
+++ b/README.md
@@ -122,3 +122,48 @@ reference[.commitlint.config.js](./commitlint.config.js)
 - `ci` modify CI configuration and scripts
 - `types` type definition file changes
 - `wip` in development
+
+## Contributors ✨
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://blog.slashspaces.com/"><img src="https://avatars.githubusercontent.com/u/143698843?v=4?s=72" width="72px;" alt="kevin"/><br /><sub><b>kevin</b></sub></a><br /><a href="#design-d3george" title="Design">🎨</a> <a href="#tool-d3george" title="Tools">🔧</a> <a href="https://github.com/d3george/slash-admin/commits?author=d3george" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Ad3george" title="Bug reports">🐛</a> <a href="https://github.com/d3george/slash-admin/commits?author=d3george" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ydiego"><img src="https://avatars.githubusercontent.com/u/13268002?v=4?s=72" width="72px;" alt="YDiego"/><br /><sub><b>YDiego</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=ydiego" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Aydiego" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fuxiaochen.com/"><img src="https://avatars.githubusercontent.com/u/65325004?v=4?s=72" width="72px;" alt="付小晨"/><br /><sub><b>付小晨</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=aifuxi" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Aaifuxi" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/xinmans"><img src="https://avatars.githubusercontent.com/u/2713008?v=4?s=72" width="72px;" alt="xinmans"/><br /><sub><b>xinmans</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=xinmans" title="Code">💻</a> <a href="#tool-xinmans" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/stitchLau"><img src="https://avatars.githubusercontent.com/u/52861440?v=4?s=72" width="72px;" alt="stitch"/><br /><sub><b>stitch</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=stitchLau" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3AstitchLau" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ntscshen"><img src="https://avatars.githubusercontent.com/u/21041458?v=4?s=72" width="72px;" alt="ntscshen"/><br /><sub><b>ntscshen</b></sub></a><br /><a href="#tool-ntscshen" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/298977887"><img src="https://avatars.githubusercontent.com/u/127030474?v=4?s=72" width="72px;" alt="298977887"/><br /><sub><b>298977887</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=298977887" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.yuque.com/eternallycyf"><img src="https://avatars.githubusercontent.com/u/63464198?v=4?s=72" width="72px;" alt="eternallycyf"/><br /><sub><b>eternallycyf</b></sub></a><br /><a href="#tool-eternallycyf" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/hugepizza"><img src="https://avatars.githubusercontent.com/u/23519941?v=4?s=72" width="72px;" alt="lei"/><br /><sub><b>lei</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/issues?q=author%3Ahugepizza" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/fliu2476"><img src="https://avatars.githubusercontent.com/u/19582252?v=4?s=72" width="72px;" alt="fliu2476"/><br /><sub><b>fliu2476</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/issues?q=author%3Afliu2476" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/chenyuxi2002"><img src="https://avatars.githubusercontent.com/u/59554586?v=4?s=72" width="72px;" alt="tzcat8"/><br /><sub><b>tzcat8</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=chenyuxi2002" title="Documentation">📖</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">All Contributors</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -152,15 +152,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/chenyuxi2002"><img src="https://avatars.githubusercontent.com/u/59554586?v=4?s=72" width="72px;" alt="tzcat8"/><br /><sub><b>tzcat8</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=chenyuxi2002" title="Documentation">📖</a></td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td align="center" size="13px" colspan="7">
-        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
-          <a href="https://all-contributors.js.org/docs/en/bot/usage">All Contributors</a>
-        </img>
-      </td>
-    </tr>
-  </tfoot>
 </table>
 
 <!-- markdownlint-restore -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,3 +122,48 @@ Docker Compose 根据`docker-compose.yaml`定义的配置构建镜像并在后�
 - `ci` 修改CI配置、脚本
 - `types` 类型定义文件修改
 - `wip` 开发中
+
+## 参与献者 ✨
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+感谢这些出色的贡献者 ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://blog.slashspaces.com/"><img src="https://avatars.githubusercontent.com/u/143698843?v=4?s=72" width="72px;" alt="kevin"/><br /><sub><b>kevin</b></sub></a><br /><a href="#design-d3george" title="Design">🎨</a> <a href="#tool-d3george" title="Tools">🔧</a> <a href="https://github.com/d3george/slash-admin/commits?author=d3george" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Ad3george" title="Bug reports">🐛</a> <a href="https://github.com/d3george/slash-admin/commits?author=d3george" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ydiego"><img src="https://avatars.githubusercontent.com/u/13268002?v=4?s=72" width="72px;" alt="YDiego"/><br /><sub><b>YDiego</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=ydiego" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Aydiego" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fuxiaochen.com/"><img src="https://avatars.githubusercontent.com/u/65325004?v=4?s=72" width="72px;" alt="付小晨"/><br /><sub><b>付小晨</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=aifuxi" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3Aaifuxi" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/xinmans"><img src="https://avatars.githubusercontent.com/u/2713008?v=4?s=72" width="72px;" alt="xinmans"/><br /><sub><b>xinmans</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=xinmans" title="Code">💻</a> <a href="#tool-xinmans" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/stitchLau"><img src="https://avatars.githubusercontent.com/u/52861440?v=4?s=72" width="72px;" alt="stitch"/><br /><sub><b>stitch</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=stitchLau" title="Code">💻</a> <a href="https://github.com/d3george/slash-admin/issues?q=author%3AstitchLau" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ntscshen"><img src="https://avatars.githubusercontent.com/u/21041458?v=4?s=72" width="72px;" alt="ntscshen"/><br /><sub><b>ntscshen</b></sub></a><br /><a href="#tool-ntscshen" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/298977887"><img src="https://avatars.githubusercontent.com/u/127030474?v=4?s=72" width="72px;" alt="298977887"/><br /><sub><b>298977887</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=298977887" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.yuque.com/eternallycyf"><img src="https://avatars.githubusercontent.com/u/63464198?v=4?s=72" width="72px;" alt="eternallycyf"/><br /><sub><b>eternallycyf</b></sub></a><br /><a href="#tool-eternallycyf" title="Tools">🔧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/hugepizza"><img src="https://avatars.githubusercontent.com/u/23519941?v=4?s=72" width="72px;" alt="lei"/><br /><sub><b>lei</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/issues?q=author%3Ahugepizza" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/fliu2476"><img src="https://avatars.githubusercontent.com/u/19582252?v=4?s=72" width="72px;" alt="fliu2476"/><br /><sub><b>fliu2476</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/issues?q=author%3Afliu2476" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/chenyuxi2002"><img src="https://avatars.githubusercontent.com/u/59554586?v=4?s=72" width="72px;" alt="tzcat8"/><br /><sub><b>tzcat8</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=chenyuxi2002" title="Documentation">📖</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">All Contributors</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -152,15 +152,6 @@ Docker Compose 根据`docker-compose.yaml`定义的配置构建镜像并在后�
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/chenyuxi2002"><img src="https://avatars.githubusercontent.com/u/59554586?v=4?s=72" width="72px;" alt="tzcat8"/><br /><sub><b>tzcat8</b></sub></a><br /><a href="https://github.com/d3george/slash-admin/commits?author=chenyuxi2002" title="Documentation">📖</a></td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td align="center" size="13px" colspan="7">
-        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
-          <a href="https://all-contributors.js.org/docs/en/bot/usage">All Contributors</a>
-        </img>
-      </td>
-    </tr>
-  </tfoot>
 </table>
 
 <!-- markdownlint-restore -->

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/styled-components": "^5.1.28",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "all-contributors-cli": "^6.26.1",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.51.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^5.62.0
     version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+  all-contributors-cli:
+    specifier: ^6.26.1
+    version: 6.26.1
   autoprefixer:
     specifier: ^10.4.16
     version: 10.4.19(postcss@8.4.38)
@@ -2061,6 +2064,27 @@ packages:
       uri-js: 4.4.1
     dev: true
 
+  /all-contributors-cli@6.26.1:
+    resolution: {integrity: sha512-Ymgo3FJACRBEd1eE653FD1J/+uD0kqpUNYfr9zNC1Qby0LgbhDBzB3EF6uvkAbYpycStkk41J+0oo37Lc02yEw==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      async: 3.2.5
+      chalk: 4.1.2
+      didyoumean: 1.2.2
+      inquirer: 7.3.3
+      json-fixer: 1.6.15
+      lodash: 4.17.21
+      node-fetch: 2.7.0
+      pify: 5.0.0
+      yargs: 15.4.1
+    optionalDependencies:
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -2401,6 +2425,10 @@ packages:
   /async-validator@4.2.5:
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
     dev: false
+
+  /async@3.2.5:
+    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
+    dev: true
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2750,6 +2778,10 @@ packages:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: true
 
+  /chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+    dev: true
+
   /chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -2778,6 +2810,13 @@ packages:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
     dev: false
 
+  /cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+    dependencies:
+      restore-cursor: 3.1.0
+    dev: true
+
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2798,9 +2837,22 @@ packages:
       string-width: 5.1.2
     dev: true
 
+  /cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+    dev: true
+
+  /cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
     dev: true
 
   /cliui@8.0.1:
@@ -4054,6 +4106,15 @@ packages:
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  /external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+    dev: true
+
   /extglob@2.0.4:
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
     engines: {node: '>=0.10.0'}
@@ -4142,6 +4203,13 @@ packages:
     dependencies:
       format: 0.2.2
     dev: false
+
+  /figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: true
 
   /file-entry-cache@4.0.0:
     resolution: {integrity: sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==}
@@ -4814,6 +4882,13 @@ packages:
       '@babel/runtime': 7.24.4
     dev: false
 
+  /iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
   /ignore@4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -4907,6 +4982,25 @@ packages:
       css-in-js-utils: 3.1.0
       fast-loops: 1.1.3
     dev: false
+
+  /inquirer@7.3.3:
+    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      run-async: 2.4.1
+      rxjs: 6.6.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+    dev: true
 
   /internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
@@ -5382,6 +5476,15 @@ packages:
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
+  /json-fixer@1.6.15:
+    resolution: {integrity: sha512-TuDuZ5KrgyjoCIppdPXBMqiGfota55+odM+j2cQ5rt/XKyKmqGB3Whz1F8SN8+60yYGy/Nu5lbRZ+rx8kBIvBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/runtime': 7.24.4
+      chalk: 4.1.2
+      pegjs: 0.10.0
     dev: true
 
   /json-parse-better-errors@1.0.2:
@@ -6404,6 +6507,10 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+    dev: true
+
   /mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6465,6 +6572,18 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: true
 
   /node-releases@2.0.14:
@@ -6679,6 +6798,11 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /outvariant@1.4.2:
     resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
     dev: true
@@ -6841,6 +6965,12 @@ packages:
     resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
     dev: true
 
+  /pegjs@0.10.0:
+    resolution: {integrity: sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
+
   /picocolors@0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
     dev: true
@@ -6871,6 +7001,11 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+    dev: true
+
+  /pify@5.0.0:
+    resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
+    engines: {node: '>=10'}
     dev: true
 
   /pirates@4.0.6:
@@ -8371,6 +8506,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+    dev: true
+
   /reset-css@5.0.2:
     resolution: {integrity: sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw==}
     dev: false
@@ -8420,6 +8559,14 @@ packages:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
     dev: true
 
   /restore-cursor@4.0.0:
@@ -8487,10 +8634,22 @@ packages:
       '@babel/runtime': 7.24.4
     dev: false
 
+  /run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
+
+  /rxjs@6.6.7:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    engines: {npm: '>=2.0.0'}
+    dependencies:
+      tslib: 1.14.1
     dev: true
 
   /sade@1.8.1:
@@ -8527,6 +8686,10 @@ packages:
     resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
     dependencies:
       ret: 0.1.15
+    dev: true
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
   /sass@1.75.0:
@@ -8588,6 +8751,10 @@ packages:
   /server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
     dev: false
+
+  /set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -9531,6 +9698,13 @@ packages:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
     dev: false
 
+  /tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: true
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -9569,6 +9743,10 @@ packages:
   /toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
     dev: false
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
 
   /traverse@0.6.9:
     resolution: {integrity: sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==}
@@ -10199,6 +10377,17 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
     dev: false
 
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
+
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
@@ -10235,6 +10424,10 @@ packages:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.3
+    dev: true
+
+  /which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
     dev: true
 
   /which-typed-array@1.1.15:
@@ -10318,6 +10511,10 @@ packages:
     engines: {node: '>=0.4'}
     dev: true
 
+  /y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: true
+
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -10352,6 +10549,14 @@ packages:
       camelcase: 4.1.0
     dev: true
 
+  /yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: true
+
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -10360,6 +10565,23 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
     dev: true
 
   /yargs@17.7.2:


### PR DESCRIPTION
本次 PR 通过添加 `.all-contributorsrc` 文件来设置 All Contributors 工具，并更新了 `README.md` 文件以包含贡献者部分。此更改有助于认可以任何形式对项目做出贡献的所有个人，促进更加合作的环境。

**包含的更改**：
- 添加 `.all-contributorsrc` 文件
- 在 `README.md` 中添加贡献者部分


考虑到项目是一个技术驱动的后台管理系统，可能需要更多自定义配置，并且贡献者相对固定，选择All Contributors CLI的方式，而不是通过机器人去创建。

为什么选择 All Contributors：
1. 增强社区归属感：在 README 中公开展示贡献者的名单和贡献类型，增强成员归属感，会感到更加受尊重和欣赏，从而更愿意继续参与项目。
2. 认可各种贡献：不仅仅认可代码贡献，还包括文档、设计、测试、项目管理等多种形式的贡献，可以激励更多人参与项目
3. 建立积极的项目文化：将 All Contributors 集成到项目中表现出项目的开发者们对建立一个包容和积极的社区文化的实践和承诺。这种文化对于保持项目**长期的活力和吸引力**是至关重要的。

内容展示 https://github.com/ntscshen/slash-admin/blob/setup-all-contributors/README.md ：
<img width="1046" alt="image" src="https://github.com/d3george/slash-admin/assets/21041458/d044eeef-d5af-4791-85ff-7694295a23eb">
<img width="1135" alt="image" src="https://github.com/d3george/slash-admin/assets/21041458/ca39faff-5241-4115-be8f-3684ff713089">
