### PR TITLE
fix: docker build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . ./
 # config node options
 ENV NODE_OPTIONS=--max_old_space_size=8192
 # config pnpm, install dependencies and build
-RUN npm install pnpm -g && \
+RUN npm install pnpm@8.x -g && \
     pnpm install && \
     pnpm build
 RUN echo "build successful  🎉 🎉 🎉"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build stage
-FROM node:16-alpine as build-stage
+FROM node:22-alpine as build-stage
 # make the 'app' folder the current working directory
 WORKDIR /app
 # copy project files and folders to the current working directory (i.e. 'app' folder)
@@ -7,7 +7,7 @@ COPY . ./
 # config node options
 ENV NODE_OPTIONS=--max_old_space_size=8192
 # config pnpm, install dependencies and build
-RUN npm install pnpm@8.x -g && \
+RUN npm install pnpm@9.x -g && \
     pnpm install && \
     pnpm build
 RUN echo "build successful  🎉 🎉 🎉"


### PR DESCRIPTION
Build will cause the following error:
```shell
ERROR: This version of pnpm requires at least Node.js v18.12
14.92 The current version of Node.js is v16.20.2
```

Default install `pnpm`(version 9) need `node > = v18.12`.
Keep the version consistent with [github ci](https://github.com/d3george/slash-admin/blob/main/.github/workflows/ci.yml).