### PR TITLE
chore: optimize dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@
 FROM node:22-alpine as build-stage
 # make the 'app' folder the current working directory
 WORKDIR /app
-# copy project files and folders to the current working directory (i.e. 'app' folder)
-COPY . ./
 # config node options
 ENV NODE_OPTIONS=--max_old_space_size=8192
-# config pnpm, install dependencies and build
+# config pnpm, install dependencies
+COPY package.json pnpm-lock.yaml* ./
 RUN npm install pnpm@9.x -g && \
-    pnpm install && \
-    pnpm build
+    pnpm install --frozen-lockfile
+# copy project files and folders to the current working directory (i.e. 'app' folder)
+COPY . ./
+# Run the build command to build the project
+RUN pnpm build
 RUN echo "build successful  🎉 🎉 🎉"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install pnpm@9.x -g && \
     pnpm install --frozen-lockfile
 # copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY . ./
-# Run the build command to build the project
+# build the project
 RUN pnpm build
 RUN echo "build successful  🎉 🎉 🎉"
 


### PR DESCRIPTION
Add a cache layer to the Dockerfile to utilize cached data when **dependencies have not changed**. 

For example
🚀 during subsequent builds:
<img width="1045" alt="image" src="https://github.com/d3george/slash-admin/assets/31346321/5544f568-a4c9-4cdd-8d72-75df98c23af3">
