### PR TITLE
feat: improve content scroll behavior and transitions when layout cha…

### DIFF
--- a/src/layouts/dashboard/config.ts
+++ b/src/layouts/dashboard/config.ts
@@ -6,3 +6,7 @@ export const HEADER_HEIGHT = 80;
 export const OFFSET_HEADER_HEIGHT = 64;
 
 export const MULTI_TABS_HEIGHT = 32;
+
+export const LAYOUT_TRANSITION = "200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms";
+
+export const SCROLL_THRESHOLD = 100;

--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -16,6 +16,7 @@ import SettingButton from "../_common/setting-button";
 
 import {
 	HEADER_HEIGHT,
+	LAYOUT_TRANSITION,
 	NAV_COLLAPSED_WIDTH,
 	NAV_WIDTH,
 	OFFSET_HEADER_HEIGHT,
@@ -23,16 +24,17 @@ import {
 import NavVertical from "./nav/nav-vertical";
 
 import { ThemeLayout } from "#/enum";
+import { useScrollTop } from "./scroll-context";
 
 type Props = {
 	className?: string;
-	offsetTop?: boolean;
 };
-export default function Header({ className = "", offsetTop = false }: Props) {
+export default function Header({ className = "" }: Props) {
 	const [drawerOpen, setDrawerOpen] = useState(false);
 	const { themeLayout, breadCrumb } = useSettings();
 	const { colorBgElevated, colorBorder } = useThemeToken();
 	const { screenMap } = useResponsive();
+	const { offsetTop } = useScrollTop();
 
 	const headerStyle: CSSProperties = {
 		position: themeLayout === ThemeLayout.Horizontal ? "relative" : "fixed",
@@ -41,6 +43,7 @@ export default function Header({ className = "", offsetTop = false }: Props) {
 				? `1px dashed ${Color(colorBorder).alpha(0.6).toString()}`
 				: "",
 		backgroundColor: Color(colorBgElevated).alpha(1).toString(),
+		transition: `height ${LAYOUT_TRANSITION}`,
 	};
 
 	if (themeLayout === ThemeLayout.Horizontal) {
@@ -62,7 +65,6 @@ export default function Header({ className = "", offsetTop = false }: Props) {
 					className="flex flex-grow items-center justify-between px-4 text-gray backdrop-blur xl:px-6 2xl:px-10"
 					style={{
 						height: offsetTop ? OFFSET_HEADER_HEIGHT : HEADER_HEIGHT,
-						transition: "height 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
 					}}
 				>
 					<div className="flex items-baseline">

--- a/src/layouts/dashboard/index.tsx
+++ b/src/layouts/dashboard/index.tsx
@@ -1,13 +1,5 @@
 import { Layout } from "antd";
-import { useScroll } from "framer-motion";
-import {
-	Suspense,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { Suspense, useMemo } from "react";
 import styled from "styled-components";
 
 import { CircleLoading } from "@/components/loading";
@@ -20,27 +12,10 @@ import Main from "./main";
 import Nav from "./nav";
 
 import { ThemeLayout, ThemeMode } from "#/enum";
+import { ScrollProvider } from "./scroll-context";
 
 function DashboardLayout() {
 	const { themeLayout, themeMode } = useSettings();
-
-	const mainEl = useRef<HTMLDivElement>(null);
-	const { scrollY } = useScroll({ container: mainEl });
-
-	/**
-	 *  Tracks if content is scrolled
-	 */
-	const [offsetTop, setOffsetTop] = useState(false);
-
-	const onOffSetTop = useCallback(() => {
-		scrollY.on("change", (scrollHeight) => {
-			setOffsetTop(scrollHeight > 0);
-		});
-	}, [scrollY]);
-
-	useEffect(() => {
-		onOffSetTop();
-	}, [onOffSetTop]);
 
 	// Memoize layout className
 	const layoutClassName = useMemo(() => {
@@ -56,13 +31,11 @@ function DashboardLayout() {
 			<Layout className={layoutClassName}>
 				<Suspense fallback={<CircleLoading />}>
 					<Layout>
-						<Header
-							offsetTop={
-								themeLayout === ThemeLayout.Vertical ? offsetTop : undefined
-							}
-						/>
-						<Nav />
-						<Main ref={mainEl} offsetTop={offsetTop} />
+						<ScrollProvider>
+							<Header />
+							<Nav />
+							<Main />
+						</ScrollProvider>
 					</Layout>
 				</Suspense>
 			</Layout>

--- a/src/layouts/dashboard/main.tsx
+++ b/src/layouts/dashboard/main.tsx
@@ -1,5 +1,5 @@
 import { Content } from "antd/es/layout/layout";
-import { type CSSProperties, forwardRef } from "react";
+import { type CSSProperties, useRef } from "react";
 import { Outlet } from "react-router";
 
 import { useSettings } from "@/store/settingStore";
@@ -8,27 +8,45 @@ import { cn } from "@/utils";
 
 import {
 	HEADER_HEIGHT,
+	LAYOUT_TRANSITION,
 	MULTI_TABS_HEIGHT,
 	NAV_COLLAPSED_WIDTH,
 	NAV_WIDTH,
+	OFFSET_HEADER_HEIGHT,
+	SCROLL_THRESHOLD,
 } from "./config";
 import MultiTabs from "./multi-tabs";
 import { MultiTabsProvider } from "./multi-tabs/multi-tabs-provider";
 
+import { useScroll } from "framer-motion";
+import { useMount, useUnmount } from "react-use";
 import { ThemeLayout } from "#/enum";
+import { useScrollTop } from "./scroll-context";
 
-type Props = {
-	offsetTop?: boolean;
-};
-const Main = forwardRef<HTMLDivElement, Props>(({ offsetTop = false }, ref) => {
+const Main = () => {
 	const { themeStretch, themeLayout, multiTab } = useSettings();
 	const { colorBgElevated } = useThemeToken();
 	const { screenMap } = useResponsive();
 
+	const scrollEle = useRef<HTMLDivElement>(null);
+	const { scrollY } = useScroll({ container: scrollEle });
+	const { offsetTop, setOffsetTop } = useScrollTop();
+
+	useMount(() => {
+		scrollY.on("change", (scrollHeight) => {
+			setOffsetTop(scrollHeight > SCROLL_THRESHOLD);
+		});
+	});
+	useUnmount(() => {
+		scrollY.destroy();
+	});
+
 	const mainStyle: CSSProperties = {
-		paddingTop: HEADER_HEIGHT + (multiTab ? MULTI_TABS_HEIGHT : 0),
+		paddingTop:
+			(offsetTop ? OFFSET_HEADER_HEIGHT : HEADER_HEIGHT) +
+			(multiTab ? MULTI_TABS_HEIGHT : 0),
 		background: colorBgElevated,
-		transition: "padding 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+		transition: `padding-top ${LAYOUT_TRANSITION}`,
 		width: "100%",
 	};
 	if (themeLayout === ThemeLayout.Horizontal) {
@@ -43,24 +61,26 @@ const Main = forwardRef<HTMLDivElement, Props>(({ offsetTop = false }, ref) => {
 	}
 
 	return (
-		<Content ref={ref} style={mainStyle} className="flex overflow-auto">
-			<div
-				className={cn(
-					"m-auto h-full w-full flex-grow sm:p-2",
-					themeStretch ? "" : "xl:max-w-screen-xl",
-					themeLayout === ThemeLayout.Horizontal ? "flex-col" : "flex-row",
-				)}
-			>
-				{multiTab ? (
-					<MultiTabsProvider>
-						<MultiTabs offsetTop={offsetTop} />
-					</MultiTabsProvider>
-				) : (
-					<Outlet />
-				)}
+		<Content style={mainStyle} className="flex overflow-hidden">
+			<div className="flex-grow size-full overflow-auto" ref={scrollEle}>
+				<div
+					className={cn(
+						"m-auto h-full w-full flex-grow sm:p-2",
+						themeStretch ? "" : "xl:max-w-screen-xl",
+						themeLayout === ThemeLayout.Horizontal ? "flex-col" : "flex-row",
+					)}
+				>
+					{multiTab ? (
+						<MultiTabsProvider>
+							<MultiTabs offsetTop={offsetTop} />
+						</MultiTabsProvider>
+					) : (
+						<Outlet />
+					)}
+				</div>
 			</div>
 		</Content>
 	);
-});
+};
 
 export default Main;

--- a/src/layouts/dashboard/multi-tabs/index.tsx
+++ b/src/layouts/dashboard/multi-tabs/index.tsx
@@ -28,6 +28,7 @@ import { useResponsive, useThemeToken } from "@/theme/hooks";
 
 import {
 	HEADER_HEIGHT,
+	LAYOUT_TRANSITION,
 	MULTI_TABS_HEIGHT,
 	NAV_COLLAPSED_WIDTH,
 	NAV_HORIZONTAL_HEIGHT,
@@ -222,8 +223,7 @@ export default function MultiTabs({ offsetTop = false }: Props) {
 				borderStyle: "solid",
 				borderColor: themeToken.colorBorderSecondary,
 				backgroundColor: themeToken.colorBgLayout,
-				transition:
-					"color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, background 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+				transition: `color ${LAYOUT_TRANSITION}, background ${LAYOUT_TRANSITION}`,
 			};
 
 			if (isActive) {
@@ -353,7 +353,7 @@ export default function MultiTabs({ offsetTop = false }: Props) {
 		height: MULTI_TABS_HEIGHT,
 		backgroundColor: Color(colorBgElevated).alpha(1).toString(),
 		borderBottom: `1px dashed ${Color(colorBorder).alpha(0.6).toString()}`,
-		transition: "top 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+		transition: `top ${LAYOUT_TRANSITION}, width ${LAYOUT_TRANSITION}`,
 	};
 
 	if (themeLayout === ThemeLayout.Horizontal) {
@@ -486,10 +486,10 @@ export default function MultiTabs({ offsetTop = false }: Props) {
 
 const StyledMultiTabs = styled.div`
   height: 100%;
-  margin-top: 2px;
-  .anticon {
-    margin: 0px !important;
-  }
+	margin-top: 2px; 
+	.anticon {
+		margin: 0px !important; 
+	}
   .ant-tabs {
     height: 100%;
     .ant-tabs-content {

--- a/src/layouts/dashboard/nav/nav-vertical.tsx
+++ b/src/layouts/dashboard/nav/nav-vertical.tsx
@@ -14,7 +14,7 @@ import { menuFilter } from "@/router/utils";
 import { useSettingActions, useSettings } from "@/store/settingStore";
 import { useThemeToken } from "@/theme/hooks";
 
-import { NAV_WIDTH } from "../config";
+import { LAYOUT_TRANSITION, NAV_WIDTH } from "../config";
 
 import NavLogo from "./nva-logo";
 
@@ -104,6 +104,7 @@ export default function NavVertical(props: Props) {
 			style={{
 				height: "100vh",
 				borderRight: `1px dashed ${Color(colorBorder).alpha(0.6).toString()}`,
+				transition: `all ${LAYOUT_TRANSITION}, background 0ms`,
 			}}
 		>
 			<NavLogo collapsed={collapsed} onToggle={handleToggleCollapsed} />

--- a/src/layouts/dashboard/nav/nva-logo.tsx
+++ b/src/layouts/dashboard/nav/nva-logo.tsx
@@ -5,8 +5,9 @@ import { useSettings } from "@/store/settingStore";
 import { useThemeToken } from "@/theme/hooks";
 import { cn } from "@/utils";
 
-import { HEADER_HEIGHT } from "../config";
+import { HEADER_HEIGHT, LAYOUT_TRANSITION } from "../config";
 
+import type { CSSProperties } from "react";
 import { ThemeLayout } from "#/enum";
 
 type Props = {
@@ -21,6 +22,13 @@ export default function NavLogo({ collapsed, onToggle }: Props) {
 		colorBgContainer,
 		colorBorderSecondary,
 	} = useThemeToken();
+
+	const logoTextStyle: CSSProperties = {
+		color: colorPrimary,
+		width: collapsed ? 0 : "auto",
+		transition: `all ${LAYOUT_TRANSITION}`,
+	};
+
 	return (
 		<div
 			style={{ height: `${HEADER_HEIGHT}px` }}
@@ -29,10 +37,7 @@ export default function NavLogo({ collapsed, onToggle }: Props) {
 			<div className="flex items-center">
 				<Logo />
 				{themeLayout !== ThemeLayout.Mini && (
-					<span
-						className="ml-2 text-xl font-bold"
-						style={{ color: colorPrimary }}
-					>
+					<span className="ml-2 text-xl font-bold" style={logoTextStyle}>
 						Slash Admin
 					</span>
 				)}

--- a/src/layouts/dashboard/scroll-context.tsx
+++ b/src/layouts/dashboard/scroll-context.tsx
@@ -1,0 +1,41 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+
+const noop = () => {};
+
+// context for scrollTop
+type ScrollContextType = {
+	offsetTop: boolean;
+	setOffsetTop: (value: boolean) => void;
+};
+const ScrollContext = createContext<ScrollContextType>({
+	offsetTop: false,
+	setOffsetTop: noop,
+});
+
+export const ScrollProvider = ({ children }: { children: React.ReactNode }) => {
+	const [offsetTop, setOffsetTop] = useState(false);
+
+	const offsetTopValue = useMemo(() => {
+		return offsetTop;
+	}, [offsetTop]);
+
+	const setOffsetTopValue = useCallback((value: boolean) => {
+		setOffsetTop(value);
+	}, []);
+
+	return (
+		<ScrollContext.Provider
+			value={{ offsetTop: offsetTopValue, setOffsetTop: setOffsetTopValue }}
+		>
+			{children}
+		</ScrollContext.Provider>
+	);
+};
+
+export const useScrollTop = () => useContext(ScrollContext);


### PR DESCRIPTION
#107 
1. 解决了内容区域的滚动条部分在header的问题。
2. 调整transition，统一layout的过渡效果。

![PixPin_2024-12-06_23-31-44](https://github.com/user-attachments/assets/40f24954-0937-41b3-8ce5-eb31dee78c7f)
![PixPin_2024-12-06_23-33-37](https://github.com/user-attachments/assets/81e894eb-9655-4112-9792-ba3c16c6ff64)
