### PR TITLE
fix: improve tab dnd sorting logic, use correct key property to find indices

### DIFF
--- a/src/layouts/dashboard/multi-tabs/components/sortable-container.tsx
+++ b/src/layouts/dashboard/multi-tabs/components/sortable-container.tsx
@@ -47,10 +47,12 @@ const SortableContainer: React.FC<SortableContainerProps> = ({ items, onSortEnd,
 		setActiveId(null);
 
 		if (over && active.id !== over.id) {
-			const oldIndex = items.findIndex((item) => item.id === active.id);
-			const newIndex = items.findIndex((item) => item.id === over.id);
+			const oldIndex = items.findIndex((item) => item.key === active.id);
+			const newIndex = items.findIndex((item) => item.key === over.id);
 
-			onSortEnd?.(oldIndex, newIndex);
+			if (oldIndex !== -1 && newIndex !== -1) {
+				onSortEnd?.(oldIndex, newIndex);
+			}
 		}
 	};
 


### PR DESCRIPTION
tab拖拽bug：只能拖拽到最后一个

before
![before](https://github.com/user-attachments/assets/62cf37d4-f0ec-43ab-b556-f9d2f1d6ef48)

now
![now](https://github.com/user-attachments/assets/845c3998-f2e4-48bd-826c-8e72c08a7ce1)
