### PR TITLE
fix: React does not recognize the `fillContainer` prop on a DOM element.

### DIFF
--- a/src/components/scrollbar/index.tsx
+++ b/src/components/scrollbar/index.tsx
@@ -29,7 +29,7 @@ const Scrollbar = forwardRef<HTMLElement, ScrollbarProps>(
 export default Scrollbar;
 
 const ScrollbarRoot = styled(SimpleBar).withConfig({
-	shouldForwardProp: (prop: string) => !["fillContent"].includes(prop),
+	shouldForwardProp: (prop: string) => !["fillContainer"].includes(prop),
 	displayName: "ScrollbarRoot",
 })<Pick<ScrollbarProps, "fillContainer">>`
   min-width: 0;


### PR DESCRIPTION
### Summary
fix the Console panel error: Warning: "React does not recognize the `fillContainer` prop on a DOM element."

![image](https://github.com/user-attachments/assets/cffe7e4c-50eb-42e3-8e96-5d522ade1a0e)
