### PR TITLE
fix: fix the `z-index` of `Header`

### DIFF
--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -21,7 +21,7 @@ export default function Header({ headerLeftSlot }: HeaderProps) {
 			data-slot="slash-layout-header"
 			className={cn(
 				"sticky top-0 right-0 left-auto flex items-center bg-background justify-between px-2 md:px-4 lg:px-6 xl:px-10",
-				"z-app-bar",
+				"z-header",
 				"h-[var(--layout-header-height)]",
 			)}
 		>

--- a/src/theme/tokens/base.ts
+++ b/src/theme/tokens/base.ts
@@ -57,6 +57,7 @@ export const baseThemeTokens = {
 		disabledBackground: "24%",
 	},
 	zIndex: {
+		header: "1000", // z-index of the header bar
 		appBar: "1100", // z-index of the navigation bar at the top of the application
 		drawer: "1200", // z-index of the drawer/navigation menu
 		modal: "1300", // z-index of the modal/dialog

--- a/src/theme/type.ts
+++ b/src/theme/type.ts
@@ -180,6 +180,7 @@ export const themeTokens = {
 		disabledBackground: null,
 	},
 	zIndex: {
+		header: null,
 		appBar: null,
 		drawer: null,
 		modal: null,


### PR DESCRIPTION
#141 fix the z-index of Header component which would cause problem that covering the NavBar's toggle button

- add 'header' zIndex token
- change Header's z-index from 'z-app-bar' to 'z-header'