### PR TITLE
fix(setting-button): 修复 ESC 退出全屏状态不同步

### DIFF
--- a/src/layouts/components/setting-button.tsx
+++ b/src/layouts/components/setting-button.tsx
@@ -14,7 +14,8 @@ import { Switch } from "@/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 import { Text } from "@/ui/typography";
 import { cn } from "@/utils";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useState } from "react";
+
 import { useTranslation } from "react-i18next";
 import screenfull from "screenfull";
 import { type ThemeColorPresets, ThemeLayout, ThemeMode } from "#/enum";
@@ -37,17 +38,41 @@ export default function SettingButton() {
 		backgroundImage: `url("${CyanBlur}"), url("${RedBlur}")`,
 		backgroundRepeat: "no-repeat, no-repeat",
 		backgroundPosition: "right top, left bottom",
-		backgroundSize: "50, 50%",
+		backgroundSize: "50%, 50%",
 	};
 
 	const [isFullscreen, setIsFullscreen] = useState(screenfull.isFullscreen);
 	const toggleFullScreen = () => {
 		if (screenfull.isEnabled) {
 			screenfull.toggle();
-			setIsFullscreen(!isFullscreen);
 		}
 	};
+	const handleKeyDown = useCallback((event: KeyboardEvent) => {
+		if (event.key === "Escape" && screenfull.isEnabled && screenfull.isFullscreen) {
+			setIsFullscreen(false);
+		}
+	}, []);
 
+	useEffect(() => {
+		const onFullscreenChange = () => {
+			if (screenfull.isEnabled) {
+				setIsFullscreen(screenfull.isFullscreen);
+			}
+		};
+
+		if (screenfull.isEnabled) {
+			screenfull.on("change", onFullscreenChange);
+		}
+
+		window.addEventListener("keydown", handleKeyDown);
+
+		return () => {
+			if (screenfull.isEnabled) {
+				screenfull.off("change", onFullscreenChange);
+			}
+			window.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [handleKeyDown]);
 	const layoutBackground = (layout: ThemeLayout) =>
 		themeLayout === layout ? themeVars.colors.palette.primary.light : themeVars.colors.palette.gray[500];
 


### PR DESCRIPTION
### 问题
设置按钮的全屏状态在按 Escape 键退出全屏时未同步更新，导致 isFullscreen 仍为 true。

### 更改
- 使用 screenfull 的 change 事件监听全屏状态变化，动态更新 isFullscreen。
- 优化 handleKeyDown 逻辑，确保 Escape 键正确处理。
- 移除 toggleFullScreen 中直接反转状态的逻辑，避免异步问题。

### 测试
- 本地测试：按钮切换全屏和 Escape 键退出全屏，isFullscreen 状态正确同步。