### PR TITLE
chore: update extensions recommendations list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"biomejs.biome",
 		"bradlc.vscode-tailwindcss",
 		"lokalise.i18n-ally",
-		"antfu.iconify"
+		"antfu.iconify",
+		"jock.svg"
 	]
 }


### PR DESCRIPTION
这里的功能实现用到了某插件的配置，但漏掉了该插件的推荐。

The implementation of the function here uses the configuration of a certain plugin, but the recommendation for this plugin has been omitted.

https://github.com/d3george/slash-admin/blob/1e653f63b6d00fd67893afa2d758733677aa084a/.vscode/settings.json#L38

