### PR TITLE
feat: update vite glob import

### DIFF
--- a/src/components/icon/register-icons.ts
+++ b/src/components/icon/register-icons.ts
@@ -39,7 +39,11 @@ export default async function registerLocalIcons() {
 		return;
 	}
 
-	const svgModules = import.meta.glob("../../assets/icons/*.svg", { as: "raw", eager: true });
+	const svgModules = import.meta.glob("../../assets/icons/*.svg", {
+		query: "?raw",
+		eager: true,
+		import: "default",
+	});
 	const icons: Record<string, IconifyIcon> = {};
 
 	for (const [path, svgContent] of Object.entries(svgModules)) {


### PR DESCRIPTION
根据文档和终端提示，使用推荐的 import 参数。

According to the documentation and terminal prompts, use the recommended import parameters.

https://github.com/vitejs/vite/blob/db9eb97b2f530a3985b29c5d1a529772f1ab1893/packages/vite/types/importGlob.d.ts#L10

Terminal tip: The glob option "as" has been deprecated in favour of "query". Please update `as: 'raw'` to `query: '?raw', import: 'default'`.