### PR TITLE
fix(animate): reset multi-item state when enabling text mode

### DIFF
--- a/src/pages/components/animate/views/inview/container.tsx
+++ b/src/pages/components/animate/views/inview/container.tsx
@@ -1,10 +1,10 @@
+import { m } from "motion/react";
+import { repeat } from "ramda";
+import { useMemo } from "react";
 import Cover3 from "@/assets/images/cover/cover_3.jpg";
 import MotionContainer from "@/components/animate/motion-container";
 import { getVariant } from "@/components/animate/variants";
 import { themeVars } from "@/theme/theme.css";
-import { m } from "motion/react";
-import { repeat } from "ramda";
-import { useMemo } from "react";
 
 const TEXT = "SlashAdmin";
 type Props = {
@@ -23,7 +23,7 @@ export default function ContainerView({ isText, variant, isMulti }: Props) {
 			style={{ backgroundColor: themeVars.colors.background.neutral }}
 		>
 			{isText ? (
-				<MotionContainer className="flex h-[480px] items-center justify-center font-bold md:text-6xl">
+				<MotionContainer key="text" className="flex h-[480px] items-center justify-center font-bold md:text-6xl">
 					{TEXT.split("").map((letter) => (
 						<m.div key={letter} variants={varients}>
 							{letter}
@@ -31,10 +31,14 @@ export default function ContainerView({ isText, variant, isMulti }: Props) {
 					))}
 				</MotionContainer>
 			) : (
-				<MotionContainer className="flex flex-col items-center justify-center gap-6">
-					{imgs.map((img) => (
+				<MotionContainer
+					key={isMulti ? "multi-image" : "single-image"}
+					className="flex flex-col items-center justify-center gap-6"
+				>
+					{imgs.map((img, index) => (
 						<m.img
-							key={img}
+							// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+							key={index}
 							src={img}
 							style={{
 								objectFit: "cover",

--- a/src/pages/components/animate/views/inview/index.tsx
+++ b/src/pages/components/animate/views/inview/index.tsx
@@ -83,12 +83,22 @@ export default function Inview() {
 		setSelectedVariant(defaultValue.selectedVariant);
 	};
 
+	/**
+	 * Text Object Toggle
+	 */
+	const handleTextToggle = (checked: boolean) => {
+		setIsText(checked);
+		if (checked) {
+			setIsMulti(false);
+		}
+	};
+
 	return (
 		<Card>
 			<CardHeader>
 				<Toolbar
 					isText={isText}
-					onChnageText={() => setIsText(!isText)}
+					onChangeText={handleTextToggle}
 					isMulti={isMulti}
 					onChangeMulti={() => setIsMulti(!isMulti)}
 					onRefresh={onRefresh}

--- a/src/pages/components/animate/views/inview/toolbar.tsx
+++ b/src/pages/components/animate/views/inview/toolbar.tsx
@@ -4,15 +4,15 @@ import { Switch } from "@/ui/switch";
 type Props = {
 	isText: boolean;
 	isMulti: boolean;
-	onChnageText: (isText: boolean) => void;
+	onChangeText: (isText: boolean) => void;
 	onChangeMulti: (isMulti: boolean) => void;
 	onRefresh: VoidFunction;
 };
-export default function Toolbar({ isText, isMulti, onChnageText, onChangeMulti, onRefresh }: Props) {
+export default function Toolbar({ isText, isMulti, onChangeText, onChangeMulti, onRefresh }: Props) {
 	return (
 		<div className="mb-4 flex items-center justify-between">
 			<div>
-				<Switch checked={isText} onCheckedChange={onChnageText} />
+				<Switch checked={isText} onCheckedChange={onChangeText} />
 				<span className="ml-2">Text Object</span>
 			</div>
 			{isText ? null : (


### PR DESCRIPTION
- 修复 Text Object 与 Multi Item 之间的状态联动问题，开启 Text Object 时会同步清空 Multi Item 状
    态，避免旧内容残留影响预览区域。
- 将 onChnageText 方法命名更正为 onChangeText。
