### PR TITLE
fix(calendar/styles): lower fc-list-day z-index to avoid dropdown ove…

### DIFF
--- a/src/pages/sys/others/calendar/styles.ts
+++ b/src/pages/sys/others/calendar/styles.ts
@@ -1,7 +1,6 @@
-import { themeVars } from "@/theme/theme.css";
 import styled from "styled-components";
-
 import { ThemeMode } from "#/enum";
+import { themeVars } from "@/theme/theme.css";
 
 export const StyledCalendar = styled.div<{ $themeMode: ThemeMode }>`
   width: 100%;
@@ -107,7 +106,7 @@ export const StyledCalendar = styled.div<{ $themeMode: ThemeMode }>`
     .fc-list {
       .fc-list-day {
         th {
-          z-index: 100;
+          z-index: 1;
         }
       }
       .fc-list-day-text,


### PR DESCRIPTION
## 问题描述

当日历切换到 `List` 视图时，`.fc-list-day th` 使用了较高的 `z-index: 100`。

由于层级过高，会导致部分浮层组件被列表头部覆盖，例如：

- DropdownMenuContent
- CalendarEventForm

<img width="2676" height="1062" alt="b7d082e607510e317cc96d8bc441c332" src="https://github.com/user-attachments/assets/8d982238-d52e-45a3-83be-c58c88faf158" />
<img width="2900" height="1500" alt="35daab5b8fe2b5487186bf0ffd01ae86" src="https://github.com/user-attachments/assets/8988499e-32f7-400c-8999-46dd4375ff52" />


## 解决方案

将 `.fc-list-day th` 的 `z-index` 从 `100` 调整为 `1`，避免覆盖页面中的浮层组件，保证下拉菜单、表单弹层等内容能够正常显示。

## 验证方式

使用较多的 Mock 数据，使 `List` 视图产生纵向滚动场景进行验证：

- DropdownMenuContent 能够正常显示在列表头部之上；
- CalendarEventForm 能够正常显示在列表头部之上；

<img width="2586" height="1362" alt="e758da5146b952203feefca5667ecc79" src="https://github.com/user-attachments/assets/f554ff02-f4ee-4705-ad08-5dc2afa520a3" />
<img width="1300" height="718" alt="image" src="https://github.com/user-attachments/assets/753a25ec-2bd4-48c3-883a-d89b03f5cb64" />

